### PR TITLE
Do not install typing for Python 3.5 and above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     ],
     install_requires=[
         'six',
-        'typing',
+        'typing; python_version<"3.5"',
     ]
 )


### PR DESCRIPTION
The `typing` module is included in the standard library since Python 3.5. Additionally, the `typing` module from PyPI is not compatible with Python 3.7 and causes breakage when e.g. running tests with `pytest`:

https://github.com/python/typing/issues/573

This PR adds an environment marker so that `typing` is installed only for older versions of Python that do not provide it in the standard library.